### PR TITLE
Make executable tests less brittle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ubuntu-latest]
+        include:
+          - python-version: 3.8
+            os: windows-latest
+          - python-version: 3.8
+            os: macos-latest
 
     steps:
       - name: Checkout repository

--- a/.pylintrc
+++ b/.pylintrc
@@ -21,4 +21,6 @@ disable=
     no-self-use,
 
     too-few-public-methods,
-    too-many-ancestors
+    too-many-ancestors,
+
+    unsubscriptable-object # false positives

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -155,11 +155,13 @@ def test_help_just_works():
 
 
 def test_check_on_formatted_file_should_return_zero():
-    assert_success("--check", case("formatted_file.cmake"))
+    with temporary_copy(case("formatted_file.cmake")) as copy:
+        assert_success("--check", copy)
 
 
 def test_check_on_not_formatted_file_should_return_one():
-    assert_fail("--check", case("not_formatted_file.cmake"))
+    with temporary_copy(case("not_formatted_file.cmake")) as copy:
+        assert_fail("--check", copy)
 
 
 def test_format_file_in_place():
@@ -210,43 +212,50 @@ def test_dont_mix_stdin_and_file_input():
 
 def test_check_multiple_formatted_input_files():
     case_ = lambda filename: case("/directory_with_formatted_files/" + filename)
-    assert_success(
-        "--check", case_("file1.cmake"), case_("file2.cmake"), case_("file3.cmake")
-    )
+    with temporary_copies(
+        [case_("file1.cmake"), case_("file2.cmake"), case_("file3.cmake")]
+    ) as copies:
+        assert_success("--check", *copies)
 
 
 def test_check_multiple_not_formatted_input_files():
     case_ = lambda filename: case("/directory_with_not_formatted_files/" + filename)
-    assert_fail(
-        "--check", case_("file1.cmake"), case_("file2.cmake"), case_("file3.cmake")
-    )
+    with temporary_copies(
+        [case_("file1.cmake"), case_("file2.cmake"), case_("file3.cmake")]
+    ) as copies:
+        assert_fail("--check", *copies)
 
 
 def test_check_multiple_input_files_when_some_are_not_formatted():
     case_ = lambda filename: case(
         "/directory_with_some_not_formatted_files/" + filename
     )
-    assert_fail(
-        "--check",
-        case_("formatted_file1.cmake"),
-        case_("formatted_file2.cmake"),
-        case_("formatted_file3.cmake"),
-        case_("not_formatted_file1.cmake"),
-        case_("not_formatted_file2.cmake"),
-        case_("not_formatted_file3.cmake"),
-    )
+    with temporary_copies(
+        [
+            case_("formatted_file1.cmake"),
+            case_("formatted_file2.cmake"),
+            case_("formatted_file3.cmake"),
+            case_("not_formatted_file1.cmake"),
+            case_("not_formatted_file2.cmake"),
+            case_("not_formatted_file3.cmake"),
+        ]
+    ) as copies:
+        assert_fail("--check", *copies)
 
 
 def test_check_directory_with_formatted_files():
-    assert_success("--check", case("directory_with_formatted_files"))
+    with temporary_dir_copy(case("directory_with_formatted_files")) as copy:
+        assert_success("--check", copy)
 
 
 def test_check_directory_with_not_formatted_files():
-    assert_fail("--check", case("directory_with_not_formatted_files"))
+    with temporary_dir_copy(case("directory_with_not_formatted_files")) as copy:
+        assert_fail("--check", copy)
 
 
 def test_check_directory_with_some_not_formatted_files():
-    assert_fail("--check", case("directory_with_some_not_formatted_files"))
+    with temporary_dir_copy(case("directory_with_some_not_formatted_files")) as copy:
+        assert_fail("--check", copy)
 
 
 def test_format_in_place_multiple_formatted_files():

--- a/tests/tests_generator.py
+++ b/tests/tests_generator.py
@@ -3,8 +3,10 @@ import os
 import pathlib
 
 
-InputOnlyCase = collections.namedtuple("Case", ["name", "content"])
-InputOutputCase = collections.namedtuple("Case", ["name", "given", "expected"])
+InputOnlyCase = collections.namedtuple("InputOnlyCase", ["name", "content"])
+InputOutputCase = collections.namedtuple(
+    "InputOutputCase", ["name", "given", "expected"]
+)
 
 
 def has_extension(expected_extension):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, lint, format, mypy
+envlist = py36, py37, py38, py39, lint, format, mypy
 skip_missing_interpreters=true
 
 [testenv]


### PR DESCRIPTION
Without temporary copies of files tests could have been impacted by
presence of .gersemirc in any of the parent directories of
gersemi/tests/executable