### PR TITLE
Add gersemi as a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+-   id: gersemi
+    name: gersemi
+    description: Gersemi - A formatter to make your CMake code the real treasure.
+    entry: gersemi
+    args: ["-i"]
+    require_serial: true
+    language: python
+    types: [cmake]


### PR DESCRIPTION
Heyo :)

Adding a config to run gersemi as a https://pre-commit.com/ hook. You'd typically use it by adding the following repo config to your local `.pre-commit-config.yaml` file.

```yaml
-   repo: https://github.com/BlankSpruce/gersemi
    rev: d96b4a719ca9d4db75f197258bbe251f82ae4d63 # or tag
    hooks:
    -   id: gersemi
```

It has the advantage of running gersemi over git tracked files so e.g. won't run over files generated by cmake in a build directory, won't run over files that weren't modified (unless called explicitly with `--all-files`), supports excluding files, etc