### PR TITLE
Fix define-minor-mode warning

### DIFF
--- a/editors/emacs/gersemi.el
+++ b/editors/emacs/gersemi.el
@@ -153,7 +153,7 @@ INPUT-BUFFER, OUTPUT-BUFFER and ERROR-BUFFER serve as stdin, stdout and stderr r
   (gersemi-region (point-min) (point-max))
   )
 
-(define-minor-mode gersemi-mode ()
+(define-minor-mode gersemi-mode
   "Run gersemi before saving buffer"
   :lighter " gersemi"
   (if gersemi-mode


### PR DESCRIPTION
```Warning: Use keywords rather than deprecated positional arguments to `define-minor-mode'```

```sh
$ emacs -batch -l ert -l gersemi.el -l gersemi-tests.el -f ert-run-tests-batch-and-exit                                                                                                                                                                                                                  
Running 6 tests (2022-07-28 06:56:53+0200, selector ‘t’)                                                                                                                                                                                                                                               
   passed  1/6  gersemi-tests--shall-reformat-buffer (0.003560 sec)                                                                                                                                                                                                                                    
   passed  2/6  gersemi-tests--shall-reformat-buffer-with-non-default-args (0.003140 sec)                                                                                                                                                                                                              
   passed  3/6  gersemi-tests--shall-reformat-region (0.003200 sec)                                                                                                                                                                                                                                    
   passed  4/6  gersemi-tests--shall-reformat-region-with-non-default-args (0.003324 sec)                                                                                                                                                                                                              
   passed  5/6  gersemi-tests--when-gersemi-mode-enabled-shall-reformat-buffer-on-save (0.023486 sec)                                                                                                                                                                                                  
   passed  6/6  gersemi-tests--with-real-gersemi-should-reformat-buffer (0.163215 sec)

Ran 6 tests, 6 results as expected, 0 unexpected (2022-07-28 06:56:53+0200, 0.200267 sec)
```