### PR TITLE
feat: add experimental autosort option

### DIFF
--- a/.gersemirc.example
+++ b/.gersemirc.example
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/BlankSpruce/gersemi/master/gersemi/configuration.schema.json
 
+autosort: false
 color: false
 definitions: []
 indent: 4

--- a/gersemi/__main__.py
+++ b/gersemi/__main__.py
@@ -151,6 +151,12 @@ def create_argparser():
     [default: number of CPUs on this system]
         """,
     )
+    configuration_group.add_argument(
+        "--autosort",
+        dest="autosort",
+        action="store_true",
+        help=conf_doc["autosort"],
+    )
 
     parser.add_argument(
         dest="sources",

--- a/gersemi/base_dumper.py
+++ b/gersemi/base_dumper.py
@@ -15,9 +15,10 @@ def get_indent(indent_type: Indent) -> str:
 
 
 class BaseDumper(Interpreter):
-    def __init__(self, width, indent_type):
+    def __init__(self, width, indent_type, autosort):
         self.width = width
         self.indent_type = indent_type
+        self.autosort = autosort
         self._indent_symbol = get_indent(self.indent_type)
         self.indent_level = 0
         self.favour_expansion = False
@@ -36,6 +37,8 @@ class BaseDumper(Interpreter):
         self, children: Nodes, separator: str = "", prefix: str = "", postfix: str = ""
     ) -> Optional[str]:
         if self.favour_expansion:
+            return None
+        if self.autosort:
             return None
 
         if not contains_line_comment(children):

--- a/gersemi/command_invocation_dumpers/section_aware_command_invocation_dumper.py
+++ b/gersemi/command_invocation_dumpers/section_aware_command_invocation_dumper.py
@@ -87,5 +87,10 @@ class SectionAwareCommandInvocationDumper(ArgumentAwareCommandInvocationDumper):
             return begin
 
         with self.indented():
-            formatted_values = "\n".join(map(self.visit, rest))
+            if self.autosort:
+                formatted_values = "\n".join(
+                    sorted(map(self.visit, rest), key=lambda f: f.lower())
+                )
+            else:
+                formatted_values = "\n".join(map(self.visit, rest))
         return f"{begin}\n{formatted_values}"

--- a/gersemi/configuration.py
+++ b/gersemi/configuration.py
@@ -158,6 +158,14 @@ class Configuration:  # pylint: disable=too-many-instance-attributes
         ),
     )
 
+    autosort: bool = field(
+        default=False,
+        metadata=dict(
+            title="Autosort",
+            description="Autosort multiple arguments lists.",
+        ),
+    )
+
     def summary(self):
         hasher = sha1()
         hasher.update(repr(self).encode("utf-8"))

--- a/gersemi/configuration.schema.json
+++ b/gersemi/configuration.schema.json
@@ -82,6 +82,12 @@
       "description": "Number of workers used to format multiple files in parallel.",
       "title": "Workers",
       "type": "integer"
+    },
+    "autosort": {
+      "default": false,
+      "description": "Autosort multiple arguments lists.",
+      "title": "Autosort",
+      "type": "boolean"
     }
   },
   "title": "Configuration",

--- a/gersemi/dumper.py
+++ b/gersemi/dumper.py
@@ -11,10 +11,11 @@ class Dumper(CommandInvocationDumper, BaseDumper):
         indent_size,
         custom_command_definitions,
         list_expansion=ListExpansion.FavourInlining,
+        autosort=False,
     ):
         self.custom_command_definitions = custom_command_definitions
         self.list_expansion = list_expansion
-        super().__init__(width, indent_size)
+        super().__init__(width, indent_size, autosort)
 
     def file(self, tree):
         result = self.__default__(tree)

--- a/gersemi/formatter.py
+++ b/gersemi/formatter.py
@@ -16,12 +16,14 @@ class Formatter:
         indent: Indent,
         custom_command_definitions,
         list_expansion: ListExpansion,
+        autosort: bool,
     ):
         self.sanity_checker = sanity_checker
         self.line_length = line_length
         self.indent_type = indent
         self.custom_command_definitions = custom_command_definitions
         self.list_expansion = list_expansion
+        self.autosort = autosort
 
     def format(self, code):
         dumper = Dumper(
@@ -29,6 +31,7 @@ class Formatter:
             self.indent_type,
             self.custom_command_definitions,
             self.list_expansion,
+            self.autosort,
         )
         result = dumper.visit(PARSER.parse(code))
         self.sanity_checker(BARE_PARSER, code, result)
@@ -46,12 +49,16 @@ def create_formatter(
     indent,
     custom_command_definitions,
     list_expansion,
+    autosort,
 ):
-    sanity_checker = check_code_equivalence if do_sanity_check else noop
+    sanity_checker = (
+        check_code_equivalence if do_sanity_check and not autosort else noop
+    )
     return Formatter(
         sanity_checker,
         line_length,
         indent,
         custom_command_definitions,
         list_expansion,
+        autosort,
     )

--- a/gersemi/runner.py
+++ b/gersemi/runner.py
@@ -207,6 +207,7 @@ def handle_files_to_format(
         configuration.indent,
         custom_command_definitions,
         configuration.list_expansion,
+        configuration.autosort,
     )
     task = select_task(mode, configuration)
     execute = partial(run_task, formatter=formatter, task=task)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,7 @@ def formatter_creator():
             list_expansion=ListExpansion(
                 config.get("list_expansion", ListExpansion.FavourInlining)
             ),
+            autosort=config.get("autosort", False),
         )
 
     return creator


### PR DESCRIPTION
I was looking for such an option in cmake_format, but could not find a suitable one, as cmake_format only allows sorting in 
`add_library` and `add_executable`, i was looking for something more general and started toying around in your code.

This PR adds a --autosort options which sorts lists with multiple arguments alphabetically, like for example

```cmake
target_source(target PRIVATE c.c b.c. a.c)
````
becomes
```cmake
target_sources(
    target
    PRIVATE
        a.c
        b.c
        c.c
)
```

Which makes adding new files / link libraries and so on a bit smoother in terms of avoiding conflicts when using git.

Issues to address to leave the draft stage:

- [ ] support sorting when formatted into single line
- [ ] support sorting in commands like `set`
- [ ] support sorting in sanitizer
- [ ] add tests
- [ ] update readme

Is there any interest in such a feature?