### PR TITLE
Fix typo: s/DEFINES_FILES/DEFINES_FILE

### DIFF
--- a/gersemi/command_invocation_dumpers/module_command_dumpers.py
+++ b/gersemi/command_invocation_dumpers/module_command_dumpers.py
@@ -690,7 +690,7 @@ class WriteBasicPackageVersionFile(ArgumentAwareCommandInvocationDumper):
 
 
 class BisonTarget(ArgumentAwareCommandInvocationDumper):
-    one_value_keywords = ["COMPILE_FLAGS", "DEFINES_FILES", "VERBOSE", "REPORT_FILE"]
+    one_value_keywords = ["COMPILE_FLAGS", "DEFINES_FILE", "VERBOSE", "REPORT_FILE"]
 
 
 class DoxygenAddDocs(ArgumentAwareCommandInvocationDumper):
@@ -710,7 +710,7 @@ class EnvModuleSwap(ArgumentAwareCommandInvocationDumper):
 
 
 class FlexTarget(ArgumentAwareCommandInvocationDumper):
-    one_value_keywords = ["COMPILE_FLAGS", "DEFINES_FILES"]
+    one_value_keywords = ["COMPILE_FLAGS", "DEFINES_FILE"]
 
 
 class GettextCreateTranslations(ArgumentAwareCommandInvocationDumper):


### PR DESCRIPTION
The bison_target() and flex_target() have a single value DEFINES_FILE keyword.