### PR TITLE
Add MAKE_DIRECTORY and RESULT to file()

### DIFF
--- a/gersemi/command_invocation_dumpers/scripting_command_dumpers.py
+++ b/gersemi/command_invocation_dumpers/scripting_command_dumpers.py
@@ -379,6 +379,10 @@ class File(TwoWordKeywordIsolator, MultipleSignatureCommandInvocationDumper):
             options=["CONFIGURE_DEPENDS", "FOLLOW_SYMLINKS"],
             one_value_keywords=["GLOB_RECURSE", "LIST_DIRECTORIES", "RELATIVE"],
         ),
+        "MAKE_DIRECTORY": dict(
+            one_value_keywords=["RESULT"],
+            multi_value_keywords=["MAKE_DIRECTORY"],
+        ),
         "RENAME": dict(
             front_positional_arguments=["<oldname>", "<newname>"],
             options=["NO_REPLACE"],

--- a/tests/formatter/file_command.in.cmake
+++ b/tests/formatter/file_command.in.cmake
@@ -64,9 +64,9 @@ file(REMOVE_RECURSE foo bar)
 
 file(REMOVE_RECURSE long_filename__________________________ long_filename__________________________)
 
-file(MAKE_DIRECTORY foo bar)
+file(MAKE_DIRECTORY foo bar RESULT result)
 
-file(MAKE_DIRECTORY long_filename__________________________ long_filename__________________________)
+file(MAKE_DIRECTORY long_filename__________________________ long_filename__________________________ RESULT result)
 
 file(COPY foo bar DESTINATION baz)
 

--- a/tests/formatter/file_command.out.cmake
+++ b/tests/formatter/file_command.out.cmake
@@ -161,12 +161,13 @@ file(
     long_filename__________________________
 )
 
-file(MAKE_DIRECTORY foo bar)
+file(MAKE_DIRECTORY foo bar RESULT result)
 
 file(
     MAKE_DIRECTORY
-    long_filename__________________________
-    long_filename__________________________
+        long_filename__________________________
+        long_filename__________________________
+    RESULT result
 )
 
 file(COPY foo bar DESTINATION baz)


### PR DESCRIPTION
I'm not sure if the current behavior is intentional and correct me if I'm wrong, but I think that according to other patterns this would be a bit more consistent: MAKE_DIRECTORY is a multi-value keyword, RESULT is a one-value keyword.

Similar to other multi-value keywords in other commands. 