### PR TITLE
Add expansion_limit configuration option

### DIFF
--- a/gersemi/base_command_invocation_dumper.py
+++ b/gersemi/base_command_invocation_dumper.py
@@ -62,7 +62,7 @@ class BaseCommandInvocationDumper(BaseDumper):
         groups = self._split_arguments(arguments.children)
         group_sizes = list(map(self.group_size, groups))
 
-        favour_expansion = (self.list_expansion == ListExpansion.FavourExpansion)
+        favour_expansion = self.list_expansion == ListExpansion.FavourExpansion
         limit = get_expansion_limit(
             self.expansion_limits, favour_expansion=favour_expansion
         )

--- a/gersemi/builtin_commands.py
+++ b/gersemi/builtin_commands.py
@@ -4,7 +4,9 @@ from typing import Iterable, List, Mapping
 from gersemi.immutable import make_immutable
 from gersemi.keyword_kind import KeywordFormatter
 from gersemi.keywords import AnyMatcher, KeywordMatcher
-from gersemi.base_command_invocation_dumper import EXPANSION_LIMIT_INHIBIT_FAVOUR_EXPANSION)
+from gersemi.base_command_invocation_dumper import (
+    EXPANSION_LIMITS_INHIBIT_FAVOUR_EXPANSION,
+)
 from gersemi.specializations.add_custom_target import add_custom_target
 from gersemi.specializations.condition_syntax_command_invocation_dumper import (
     condition_syntax_commands,
@@ -136,7 +138,7 @@ builtin_commands = {
     ## Scripting Commands
     #
     "block": {
-        "expansion_limits": EXPANSION_LIMIT_INHIBIT_FAVOUR_EXPANSION,
+        "expansion_limits": EXPANSION_LIMITS_INHIBIT_FAVOUR_EXPANSION,
         "multi_value_keywords": ["SCOPE_FOR", "PROPAGATE"],
     },
     "break": {},
@@ -895,13 +897,13 @@ builtin_commands = {
         "multi_value_keywords": ["NAMES", "HINTS", "PATHS", "PATH_SUFFIXES"],
     },
     "foreach": {
-        "expansion_limits": EXPANSION_LIMIT_INHIBIT_FAVOUR_EXPANSION,
+        "expansion_limits": EXPANSION_LIMITS_INHIBIT_FAVOUR_EXPANSION,
         "front_positional_arguments": ["<loop_var>"],
         "options": ["IN"],
         "multi_value_keywords": ["RANGE", "LISTS", "ITEMS", "ZIP_LISTS"],
     },
     "function": {
-        "expansion_limits": EXPANSION_LIMIT_INHIBIT_FAVOUR_EXPANSION,
+        "expansion_limits": EXPANSION_LIMITS_INHIBIT_FAVOUR_EXPANSION,
         "front_positional_arguments": ["<name>"],
     },
     "get_cmake_property": {
@@ -1064,7 +1066,7 @@ builtin_commands = {
         },
     },
     "macro": {
-        "expansion_limits": EXPANSION_LIMIT_INHIBIT_FAVOUR_EXPANSION,
+        "expansion_limits": EXPANSION_LIMITS_INHIBIT_FAVOUR_EXPANSION,
         "front_positional_arguments": ["<name>"],
     },
     "mark_as_advanced": {

--- a/gersemi/builtin_commands.py
+++ b/gersemi/builtin_commands.py
@@ -4,6 +4,7 @@ from typing import Iterable, List, Mapping
 from gersemi.immutable import make_immutable
 from gersemi.keyword_kind import KeywordFormatter
 from gersemi.keywords import AnyMatcher, KeywordMatcher
+from gersemi.base_command_invocation_dumper import EXPANSION_LIMIT_INHIBIT_FAVOUR_EXPANSION)
 from gersemi.specializations.add_custom_target import add_custom_target
 from gersemi.specializations.condition_syntax_command_invocation_dumper import (
     condition_syntax_commands,
@@ -135,7 +136,7 @@ builtin_commands = {
     ## Scripting Commands
     #
     "block": {
-        "_inhibit_favour_expansion": True,
+        "expansion_limits": EXPANSION_LIMIT_INHIBIT_FAVOUR_EXPANSION,
         "multi_value_keywords": ["SCOPE_FOR", "PROPAGATE"],
     },
     "break": {},
@@ -894,13 +895,13 @@ builtin_commands = {
         "multi_value_keywords": ["NAMES", "HINTS", "PATHS", "PATH_SUFFIXES"],
     },
     "foreach": {
-        "_inhibit_favour_expansion": True,
+        "expansion_limits": EXPANSION_LIMIT_INHIBIT_FAVOUR_EXPANSION,
         "front_positional_arguments": ["<loop_var>"],
         "options": ["IN"],
         "multi_value_keywords": ["RANGE", "LISTS", "ITEMS", "ZIP_LISTS"],
     },
     "function": {
-        "_inhibit_favour_expansion": True,
+        "expansion_limits": EXPANSION_LIMIT_INHIBIT_FAVOUR_EXPANSION,
         "front_positional_arguments": ["<name>"],
     },
     "get_cmake_property": {
@@ -1063,7 +1064,7 @@ builtin_commands = {
         },
     },
     "macro": {
-        "_inhibit_favour_expansion": True,
+        "expansion_limits": EXPANSION_LIMIT_INHIBIT_FAVOUR_EXPANSION,
         "front_positional_arguments": ["<name>"],
     },
     "mark_as_advanced": {

--- a/gersemi/specializations/argument_aware_command_invocation_dumper.py
+++ b/gersemi/specializations/argument_aware_command_invocation_dumper.py
@@ -101,7 +101,6 @@ class KeywordSplitter:
 
 
 class ArgumentAwareCommandInvocationDumper(BaseCommandInvocationDumper):
-    _inhibit_favour_expansion: bool = False
     _keyword_formatters: Dict[str, str] = {}
     _canonical_name: Optional[str] = None
 

--- a/gersemi/specializations/condition_syntax_command_invocation_dumper.py
+++ b/gersemi/specializations/condition_syntax_command_invocation_dumper.py
@@ -8,7 +8,7 @@ from gersemi.ast_helpers import (
 from gersemi.base_command_invocation_dumper import (
     BaseCommandInvocationDumper,
     ExpansionLimits,
-    EXPANSION_LIMIT_INHIBIT_FAVOUR_EXPANSION,
+    EXPANSION_LIMITS_INHIBIT_FAVOUR_EXPANSION,
 )
 from gersemi.configuration import Spaces
 from gersemi.types import Nodes
@@ -122,7 +122,7 @@ def isolate_conditions(arguments: Nodes) -> Nodes:
 
 
 class ConditionSyntaxCommandInvocationDumper(BaseCommandInvocationDumper):
-    expansion_limits: ExpansionLimits = EXPANSION_LIMIT_INHIBIT_FAVOUR_EXPANSION
+    expansion_limits: ExpansionLimits = EXPANSION_LIMITS_INHIBIT_FAVOUR_EXPANSION
 
     def unary_operation(self, tree):
         result = self._try_to_format_into_single_line(tree.children)

--- a/gersemi/specializations/condition_syntax_command_invocation_dumper.py
+++ b/gersemi/specializations/condition_syntax_command_invocation_dumper.py
@@ -5,7 +5,11 @@ from gersemi.ast_helpers import (
     is_line_comment_in,
     is_one_of_keywords,
 )
-from gersemi.base_command_invocation_dumper import BaseCommandInvocationDumper
+from gersemi.base_command_invocation_dumper import (
+    BaseCommandInvocationDumper,
+    ExpansionLimits,
+    EXPANSION_LIMIT_INHIBIT_FAVOUR_EXPANSION,
+)
 from gersemi.configuration import Spaces
 from gersemi.types import Nodes
 from gersemi.utils import advance
@@ -118,7 +122,7 @@ def isolate_conditions(arguments: Nodes) -> Nodes:
 
 
 class ConditionSyntaxCommandInvocationDumper(BaseCommandInvocationDumper):
-    _inhibit_favour_expansion = True
+    expansion_limits: ExpansionLimits = EXPANSION_LIMIT_INHIBIT_FAVOUR_EXPANSION
 
     def unary_operation(self, tree):
         result = self._try_to_format_into_single_line(tree.children)

--- a/gersemi/specializations/standard_command_dumper.py
+++ b/gersemi/specializations/standard_command_dumper.py
@@ -29,7 +29,6 @@ def create_standard_dumper(data):
 
     class Impl(*bases):
         _canonical_name = data.get("_canonical_name", None)
-        _inhibit_favour_expansion = data.get("_inhibit_favour_expansion", False)
         _two_words_keywords = data.get("_two_words_keywords", ())
 
         front_positional_arguments = data.get("front_positional_arguments", ())
@@ -40,6 +39,7 @@ def create_standard_dumper(data):
         sections = data.get("sections", {})
         keyword_formatters = data.get("keyword_formatters", {})
         keyword_preprocessors = data.get("keyword_preprocessors", {})
+        expansion_limits = data.get("expansion_limits", {})
 
         if data_signatures is not None:
             signatures = data_signatures


### PR DESCRIPTION
This is still a draft, more trying to understand the code than anything else

---

Allows the ability to customize the maximum group size that is eligible for inlining using a field `expansion_limit`. This can be specified either as a single int (which is used in both `favour_inlining` and `favour_expansion` modes) or as a dict with the (optional) keys `"favour_expansion_limit"` and `"favour_expansion_limit"` to specific separate limits for each mode (if a key is omitted, the default is used for that mode).

Remove the `_inihibit_favour_expansion` field since its functionality is subsumed by `expansion_limit`

Partially addresses https://github.com/BlankSpruce/gersemi/issues/78, currently only in the per-function case